### PR TITLE
feat: add responsive chat layout with zustand

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Inflera Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "demo-ui",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "vite",
+    "build": "vite build",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "vite": "^4.5.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Sidebar from './components/Sidebar';
+import MainView from './components/MainView';
+import ChatInput from './components/ChatInput';
+
+const App = () => {
+  return (
+    <div className="app">
+      <Sidebar />
+      <div className="main">
+        <MainView />
+        <ChatInput />
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/ChatInput.jsx
+++ b/src/components/ChatInput.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { useAppStore } from '../store';
+
+const ChatInput = () => {
+  const [input, setInput] = useState('');
+  const agentMode = useAppStore((s) => s.agentMode);
+  const setAgentMode = useAppStore((s) => s.setAgentMode);
+  const addChatMessage = useAppStore((s) => s.addChatMessage);
+
+  const handleSend = () => {
+    if (!input.trim()) return;
+    addChatMessage({ sender: 'user', text: input });
+    setInput('');
+  };
+
+  return (
+    <div className="chat-input">
+      <select
+        className="mode-select"
+        value={agentMode}
+        onChange={(e) => setAgentMode(e.target.value)}
+      >
+        <option value="agent">Agent mode</option>
+        <option value="assistant">Assistant mode</option>
+      </select>
+      <input
+        className="message-field"
+        placeholder="Write a message..."
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+      />
+      <button className="send-btn" onClick={handleSend}>
+        ↑
+      </button>
+    </div>
+  );
+};
+
+export default ChatInput;

--- a/src/components/MainView.jsx
+++ b/src/components/MainView.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const MainView = () => (
+  <div className="main-view">
+    <h1>Hey Adam, Welcome To Inflera</h1>
+    <p>
+      I'm Cbie—your non-billing AI with Supreme Court smarts. Let me show you the
+      fine print!
+    </p>
+  </div>
+);
+
+export default MainView;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useAppStore } from '../store';
+
+const Sidebar = () => {
+  const taskGroups = useAppStore((s) => s.taskGroups);
+
+  return (
+    <aside className="sidebar">
+      <div className="sidebar-top">
+        <h2 className="logo">h department</h2>
+        <div className="sidebar-actions">
+          <button className="icon-btn">⚙️</button>
+          <button className="icon-btn">+</button>
+        </div>
+      </div>
+
+      <button className="create-task">Create task</button>
+
+      <div className="tasks-section">
+        <h4 className="section-title">Assigned Tasks</h4>
+        {taskGroups.map((group) => (
+          <div className="task-group" key={group.title}>
+            <h5 className="group-title">{group.title}</h5>
+            <ul>
+              {group.tasks.map((t) => (
+                <li key={t}>{t}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      <div className="footer-user">
+        <div className="avatar">AS</div>
+        <span>Adam Smith</span>
+      </div>
+    </aside>
+  );
+};
+
+export default Sidebar;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+export const useAppStore = create((set) => ({
+  agentMode: 'agent',
+  chatMessages: [],
+  taskGroups: [
+    {
+      title: 'Finance Trends in India',
+      tasks: [
+        "India's Financial Landscape",
+        'Future of Finance in India',
+        'Finance Outlook India',
+      ],
+    },
+    {
+      title: 'Finance Trends Report',
+      tasks: [
+        'Finance tips for beginners',
+      ],
+    },
+  ],
+  setAgentMode: (mode) => set({ agentMode: mode }),
+  addChatMessage: (msg) =>
+    set((state) => ({ chatMessages: [...state.chatMessages, msg] })),
+  setTaskGroups: (groups) => set({ taskGroups: groups }),
+}));

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,193 @@
+:root {
+  --bg-start: #f7faff;
+  --bg-end: #ffffff;
+  --text-color: #0e0e2c;
+  --muted-text: #5c6277;
+  --border: #e8edf3;
+  --accent: #1a73e8;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  background: linear-gradient(180deg, var(--bg-start), var(--bg-end));
+  color: var(--text-color);
+  height: 100vh;
+}
+
+.app {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 280px;
+  background: #fff;
+  border-right: 1px solid var(--border);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sidebar-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.logo {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.icon-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.create-task {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.tasks-section {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.section-title {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.9rem;
+  color: var(--muted-text);
+}
+
+.task-group {
+  margin-bottom: 1rem;
+}
+
+.group-title {
+  font-size: 0.95rem;
+  margin: 0 0 0.5rem 0;
+}
+
+.task-group ul {
+  list-style: none;
+  padding-left: 1rem;
+  margin: 0;
+}
+
+.task-group li {
+  margin-bottom: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.footer-user {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.avatar {
+  background: var(--accent);
+  color: #fff;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-size: 0.8rem;
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 2rem;
+}
+
+.main-view {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.main-view h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.main-view p {
+  color: var(--muted-text);
+  max-width: 480px;
+}
+
+.chat-input {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #fff;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+}
+
+.mode-select {
+  border: none;
+  background: transparent;
+  font-size: 0.9rem;
+  color: var(--muted-text);
+  outline: none;
+}
+
+.message-field {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 0.9rem;
+}
+
+.send-btn {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+@media (max-width: 900px) {
+  .sidebar {
+    width: 220px;
+  }
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    display: none;
+  }
+  .main {
+    padding: 1rem;
+  }
+  .chat-input {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .send-btn {
+    align-self: flex-end;
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- implement responsive layout with sidebar, main view and chat input
- add zustand store for agent mode, chat messages and task groups
- include base styles and media queries for mobile/tablet views

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bbecf28b9c832b97357005163e8c8a