### PR TITLE
Add chat collaboration screen and navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,27 @@
-import React from 'react';
+import React, { useState } from 'react';
 import AppLayout from './components/AppLayout';
 import ConnectDatasetPage from './components/connect-dataset/ConnectDatasetPage';
+import ChatPage from './components/chat/ChatPage';
+
+const pageComponents = {
+  'connect-dataset': ConnectDatasetPage,
+  chat: ChatPage,
+};
 
 const App = () => {
+  const [activePage, setActivePage] = useState('connect-dataset');
+
+  const ActiveComponent = pageComponents[activePage] ?? ConnectDatasetPage;
+
+  const handleNavigate = (pageKey) => {
+    if (pageComponents[pageKey]) {
+      setActivePage(pageKey);
+    }
+  };
+
   return (
-    <AppLayout>
-      <ConnectDatasetPage />
+    <AppLayout activePage={activePage} onNavigate={handleNavigate}>
+      <ActiveComponent />
     </AppLayout>
   );
 };

--- a/src/components/AppLayout.jsx
+++ b/src/components/AppLayout.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import Sidebar from './Sidebar';
 
-const AppLayout = ({ children }) => {
+const AppLayout = ({ children, activePage, onNavigate }) => {
   return (
     <div className="app-shell">
-      <Sidebar />
+      <Sidebar activePage={activePage} onNavigate={onNavigate} />
       <main className="app-main" role="main">
         {children}
       </main>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 
 const navItems = [
-  { label: 'Profile', href: '#profile' },
-  { label: 'Connect Dataset', href: '#connect-dataset', active: true },
-  { label: 'File Upload', href: '#file-upload' },
-  { label: 'Coin usage', href: '#coin-usage', badge: '120' },
+  { label: 'Profile', key: 'profile', disabled: true },
+  { label: 'Connect Dataset', key: 'connect-dataset' },
+  { label: 'Chat', key: 'chat' },
+  { label: 'File Upload', key: 'file-upload', disabled: true },
+  { label: 'Coin usage', key: 'coin-usage', badge: '120', disabled: true },
 ];
 
-const Sidebar = () => {
+const Sidebar = ({ activePage, onNavigate }) => {
   return (
     <aside className="sidebar" aria-label="Primary">
       <div className="sidebar__header">
@@ -17,18 +18,28 @@ const Sidebar = () => {
 
       <nav className="sidebar__nav" aria-label="Main navigation">
         <ul>
-          {navItems.map((item) => (
-            <li key={item.label}>
-              <a
-                href={item.href}
-                className={`sidebar__link${item.active ? ' is-active' : ''}`}
-                aria-current={item.active ? 'page' : undefined}
-              >
-                <span>{item.label}</span>
-                {item.badge ? <span className="sidebar__badge">{item.badge}</span> : null}
-              </a>
-            </li>
-          ))}
+          {navItems.map((item) => {
+            const isActive = item.key === activePage;
+
+            return (
+              <li key={item.key}>
+                <button
+                  type="button"
+                  className={`sidebar__link${isActive ? ' is-active' : ''}`}
+                  aria-current={isActive ? 'page' : undefined}
+                  onClick={() => {
+                    if (!item.disabled) {
+                      onNavigate?.(item.key);
+                    }
+                  }}
+                  disabled={item.disabled}
+                >
+                  <span>{item.label}</span>
+                  {item.badge ? <span className="sidebar__badge">{item.badge}</span> : null}
+                </button>
+              </li>
+            );
+          })}
         </ul>
       </nav>
 

--- a/src/components/chat/ChatPage.jsx
+++ b/src/components/chat/ChatPage.jsx
@@ -1,0 +1,271 @@
+import React from 'react';
+
+const pinnedConversations = [
+  {
+    id: 'conv-1',
+    title: 'Campaign launch with sales insights',
+    summary: 'Notes and datasets shared yesterday',
+    status: 'In progress',
+  },
+  {
+    id: 'conv-2',
+    title: 'Quarterly demand planning',
+    summary: 'Waiting for finance approval',
+    status: 'Pending',
+  },
+  {
+    id: 'conv-3',
+    title: 'Onboarding automation sprint',
+    summary: 'All workflows migrated',
+    status: 'Completed',
+  },
+];
+
+const activeTasks = [
+  { id: 'task-1', title: 'Prepare FAQ sheet for leadership', due: 'Due today' },
+  { id: 'task-2', title: 'Summarise the new NPS survey responses', due: 'Due tomorrow' },
+];
+
+const archivedTasks = [
+  { id: 'arch-1', title: 'Clean marketing attribution dataset' },
+  { id: 'arch-2', title: 'Tag historical support tickets' },
+];
+
+const chatMessages = [
+  {
+    id: 'msg-1',
+    author: 'Odie',
+    role: 'assistant',
+    time: '09:15',
+    content:
+      "Hi Adam! I can help you brief the leadership team on our hiring and engagement metrics. Would you like me to pull the latest datasets?",
+  },
+  {
+    id: 'msg-2',
+    author: 'Adam Smith',
+    role: 'user',
+    time: '09:17',
+    content:
+      'Yes please. Give me a quick overview of headcount growth by department, plus any spikes in attrition over the last quarter.',
+  },
+  {
+    id: 'msg-3',
+    author: 'Odie',
+    role: 'assistant',
+    time: '09:19',
+    content:
+      'Pulled headcount and attrition metrics from HC_Dashboard.xlsx. Marketing and Product grew the fastest (+12.4% MoM). Customer Success attrition spiked to 6.2% in March, mainly in Tier 1 roles.',
+    highlights: [
+      '• Added tables: headcount_trend.csv, attrition_breakdown.csv',
+      '• Suggested action: run exit interview theme analysis',
+    ],
+  },
+  {
+    id: 'msg-4',
+    author: 'Adam Smith',
+    role: 'user',
+    time: '09:21',
+    content: 'Great. Draft a two-slide summary highlighting risks and recommendations for the exec meeting.',
+  },
+  {
+    id: 'msg-5',
+    author: 'Odie',
+    role: 'assistant',
+    time: '09:23',
+    content:
+      'Summary drafted. Slide one covers growth by department, slide two covers attrition risk with mitigation plan. Want me to package it as a keynote deck?',
+  },
+];
+
+const ChatPage = () => {
+  return (
+    <section className="page" id="chat">
+      <header className="page-header chat-header">
+        <div>
+          <p className="page-subtitle">Workspace</p>
+          <h1>Collaborate with Odie</h1>
+          <p className="page-description">
+            Ask questions, assign work, or explore datasets in the same canvas. Your assistant keeps track of every
+            decision your team makes.
+          </p>
+        </div>
+        <div className="chat-header__actions" aria-label="Conversation controls">
+          <button type="button" className="chat-secondary-btn">Share</button>
+          <button type="button" className="chat-primary-btn">Create task</button>
+        </div>
+      </header>
+
+      <div className="chat-layout">
+        <aside className="chat-sidebar-panel" aria-label="Task overview">
+          <section className="chat-sidebar-card" aria-labelledby="chat-space-heading">
+            <header className="chat-sidebar-card__header">
+              <div>
+                <p className="chat-sidebar-card__eyebrow">Workspace</p>
+                <h2 id="chat-space-heading">Hc department</h2>
+              </div>
+              <button type="button" className="chat-tertiary-btn">+ Create task</button>
+            </header>
+
+            <div className="chat-sidebar-card__filters" role="tablist" aria-label="Conversation filters">
+              <button type="button" className="chat-chip is-active" role="tab" aria-selected="true">
+                All
+              </button>
+              <button type="button" className="chat-chip" role="tab" aria-selected="false">
+                Pinned
+              </button>
+            </div>
+
+            <ul className="chat-sidebar-list">
+              {pinnedConversations.map((conversation) => (
+                <li key={conversation.id} className="chat-sidebar-item">
+                  <div className="chat-sidebar-item__main">
+                    <h3>{conversation.title}</h3>
+                    <p>{conversation.summary}</p>
+                  </div>
+                  <span className="chat-sidebar-item__status">{conversation.status}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="chat-sidebar-card" aria-labelledby="chat-tasks-heading">
+            <header className="chat-sidebar-card__header">
+              <h2 id="chat-tasks-heading">Your tasks</h2>
+              <span className="chat-sidebar-pill">Today</span>
+            </header>
+
+            <ul className="chat-sidebar-list">
+              {activeTasks.map((task) => (
+                <li key={task.id} className="chat-sidebar-item">
+                  <div className="chat-sidebar-item__main">
+                    <h3>{task.title}</h3>
+                    <p>{task.due}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+
+            <footer className="chat-sidebar-footer">
+              <div className="chat-user-chip">
+                <span className="chat-avatar" aria-hidden="true">
+                  AS
+                </span>
+                <div>
+                  <p className="chat-user-chip__name">Adam Smith</p>
+                  <p className="chat-user-chip__role">People Operations</p>
+                </div>
+              </div>
+              <div className="chat-sidebar-footer__meta">
+                <span className="chat-token">200 coins left</span>
+              </div>
+            </footer>
+          </section>
+
+          <section className="chat-sidebar-card" aria-labelledby="chat-archive-heading">
+            <header className="chat-sidebar-card__header">
+              <h2 id="chat-archive-heading">Archive tasks</h2>
+              <span className="chat-sidebar-pill chat-sidebar-pill--muted">2</span>
+            </header>
+            <ul className="chat-sidebar-list chat-sidebar-list--compact">
+              {archivedTasks.map((task) => (
+                <li key={task.id} className="chat-sidebar-item">
+                  <div className="chat-sidebar-item__main">
+                    <h3>{task.title}</h3>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </aside>
+
+        <div className="chat-main-panel">
+          <article className="chat-welcome-card">
+            <div className="chat-welcome-card__content">
+              <div className="chat-welcome-card__intro">
+                <span className="chat-avatar chat-avatar--assistant" aria-hidden="true">
+                  O
+                </span>
+                <div>
+                  <p className="chat-welcome-card__headline">Hey Adam, Welcome to Infliera</p>
+                  <p className="chat-welcome-card__body">
+                    I&apos;m Odie—your non-billing AI with Supreme Court smarts. Let&apos;s dive into the fine print and
+                    translate it into action plans.
+                  </p>
+                </div>
+              </div>
+              <div className="chat-welcome-card__actions">
+                <button type="button" className="chat-primary-btn chat-primary-btn--ghost">
+                  Connect dataset
+                </button>
+                <button type="button" className="chat-tertiary-btn">Agent mode</button>
+              </div>
+            </div>
+          </article>
+
+          <div className="chat-thread" role="log" aria-live="polite">
+            {chatMessages.map((message) => {
+              const avatarClassName =
+                message.role === 'assistant'
+                  ? 'chat-avatar chat-avatar--assistant'
+                  : 'chat-avatar chat-avatar--user';
+              const initials = message.role === 'assistant' ? 'O' : 'AS';
+
+              return (
+                <article key={message.id} className={`chat-message chat-message--${message.role}`}>
+                  <div className="chat-message__avatar" aria-hidden="true">
+                    <span className={avatarClassName}>{initials}</span>
+                  </div>
+                  <div className="chat-message__bubble" data-role={message.role}>
+                    <header className="chat-message__meta">
+                      <span className="chat-message__author">{message.author}</span>
+                      <span className="chat-message__time">{message.time}</span>
+                    </header>
+                    <p>{message.content}</p>
+                    {message.highlights ? (
+                      <ul className="chat-message__highlights">
+                        {message.highlights.map((item) => (
+                          <li key={item}>{item}</li>
+                        ))}
+                      </ul>
+                    ) : null}
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+
+          <form className="chat-composer" aria-label="Send a message" onSubmit={(event) => event.preventDefault()}>
+            <div className="chat-composer__input">
+              <button type="button" className="chat-icon-btn" aria-label="Attach file">
+                <span aria-hidden="true">+</span>
+              </button>
+              <textarea
+                className="chat-composer__textarea"
+                placeholder="Ask, assign or search for anything..."
+                rows={1}
+                aria-label="Message"
+              />
+              <button type="button" className="chat-icon-btn" aria-label="Insert emoji">
+                <span aria-hidden="true">😊</span>
+              </button>
+            </div>
+            <div className="chat-composer__footer">
+              <div className="chat-composer__status">
+                <span className="chat-mode-chip">Agent responding in real time</span>
+                <span className="chat-token">Response ETA: 3s</span>
+              </div>
+              <div className="chat-composer__actions">
+                <button type="button" className="chat-secondary-btn">Draft email</button>
+                <button type="submit" className="chat-primary-btn">
+                  Send
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ChatPage;

--- a/src/styles.css
+++ b/src/styles.css
@@ -110,11 +110,26 @@ button:disabled {
   color: inherit;
   background: transparent;
   transition: background 0.2s ease, transform 0.2s ease;
+  border: none;
+  width: 100%;
+  text-align: left;
+  font: inherit;
 }
 
 .sidebar__link:hover {
   background: rgba(255, 255, 255, 0.08);
   transform: translateX(4px);
+}
+
+.sidebar__link:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  background: transparent;
+  transform: none;
+}
+
+.sidebar__link:disabled:hover {
+  background: transparent;
 }
 
 .sidebar__link.is-active {
@@ -465,9 +480,473 @@ button:disabled {
   font-weight: 600;
 }
 
+
+.chat-header {
+  align-items: center;
+}
+
+.chat-header__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.chat-primary-btn,
+.chat-secondary-btn,
+.chat-tertiary-btn {
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 0.8rem 1.6rem;
+  font-size: 0.95rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.chat-primary-btn {
+  border: none;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #f8fafc;
+  box-shadow: 0 16px 32px rgba(99, 102, 241, 0.28);
+}
+
+.chat-primary-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 36px rgba(99, 102, 241, 0.32);
+}
+
+.chat-primary-btn--ghost {
+  background: rgba(99, 102, 241, 0.16);
+  color: #312e81;
+  box-shadow: none;
+}
+
+.chat-primary-btn--ghost:hover {
+  background: rgba(99, 102, 241, 0.24);
+}
+
+.chat-secondary-btn {
+  border: 1px solid var(--stroke);
+  background: var(--card-background);
+  color: var(--text-primary);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+}
+
+.chat-secondary-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.chat-tertiary-btn {
+  border: 1px solid rgba(99, 102, 241, 0.24);
+  background: rgba(99, 102, 241, 0.1);
+  color: var(--accent);
+  padding-inline: 1.2rem;
+}
+
+.chat-tertiary-btn:hover {
+  background: rgba(99, 102, 241, 0.18);
+}
+
+.chat-layout {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 2rem;
+  align-items: flex-start;
+}
+
+.chat-sidebar-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.chat-sidebar-card {
+  background: var(--card-background);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--soft-stroke);
+  box-shadow: var(--shadow);
+  padding: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.chat-sidebar-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.chat-sidebar-card__eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.chat-sidebar-card__filters {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.chat-chip {
+  border-radius: 999px;
+  border: 1px solid var(--soft-stroke);
+  background: #f9fafb;
+  color: var(--text-secondary);
+  padding: 0.35rem 1rem;
+  font-weight: 500;
+  font-size: 0.82rem;
+}
+
+.chat-chip.is-active {
+  border-color: transparent;
+  background: var(--accent);
+  color: #eef2ff;
+}
+
+.chat-sidebar-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.chat-sidebar-list--compact {
+  gap: 0.65rem;
+}
+
+.chat-sidebar-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  background: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.chat-sidebar-item__main h3 {
+  margin: 0 0 0.35rem;
+  font-size: 0.98rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.chat-sidebar-item__main p {
+  margin: 0;
+  color: var(--text-tertiary);
+  font-size: 0.82rem;
+}
+
+.chat-sidebar-item__status {
+  align-self: center;
+  background: rgba(34, 197, 94, 0.14);
+  color: #15803d;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.chat-sidebar-pill {
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  background: rgba(34, 197, 94, 0.12);
+  color: #166534;
+  font-weight: 600;
+}
+
+.chat-sidebar-pill--muted {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text-tertiary);
+}
+
+.chat-sidebar-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--soft-stroke);
+}
+
+.chat-user-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.chat-user-chip__name {
+  margin: 0;
+  font-weight: 600;
+}
+
+.chat-user-chip__role {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-tertiary);
+}
+
+.chat-sidebar-footer__meta {
+  font-size: 0.8rem;
+  color: var(--text-tertiary);
+}
+
+.chat-token {
+  font-size: 0.78rem;
+  color: var(--text-tertiary);
+  font-weight: 600;
+}
+
+.chat-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #f8fafc;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.chat-avatar--assistant {
+  background: #4338ca;
+}
+
+.chat-avatar--user {
+  background: #0f172a;
+}
+
+.chat-main-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.chat-welcome-card {
+  background: linear-gradient(135deg, #eef2ff, #f8fafc);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 20px 38px rgba(99, 102, 241, 0.18);
+}
+
+.chat-welcome-card__content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+}
+
+.chat-welcome-card__intro {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  max-width: 520px;
+}
+
+.chat-welcome-card__headline {
+  margin: 0 0 0.35rem;
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.chat-welcome-card__body {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.chat-welcome-card__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.chat-thread {
+  background: var(--card-background);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--soft-stroke);
+  box-shadow: var(--shadow);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.chat-message {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.chat-message--user {
+  flex-direction: row-reverse;
+}
+
+.chat-message__bubble {
+  background: #f5f6ff;
+  border-radius: 1.2rem;
+  padding: 1rem 1.25rem;
+  max-width: 520px;
+  box-shadow: 0 12px 24px rgba(148, 163, 184, 0.18);
+}
+
+.chat-message__bubble[data-role='assistant'] {
+  border: 1px solid rgba(99, 102, 241, 0.18);
+}
+
+.chat-message__bubble[data-role='user'] {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #f9fafb;
+  box-shadow: none;
+}
+
+.chat-message__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.78rem;
+  color: var(--text-tertiary);
+  margin-bottom: 0.5rem;
+}
+
+.chat-message__author {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.chat-message--user .chat-message__meta {
+  justify-content: flex-end;
+  color: rgba(248, 250, 252, 0.78);
+}
+
+.chat-message__bubble p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.chat-message__highlights {
+  margin: 0.8rem 0 0;
+  padding-left: 1.1rem;
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+}
+
+.chat-message__bubble[data-role='user'] .chat-message__highlights {
+  color: rgba(248, 250, 252, 0.9);
+}
+
+.chat-composer {
+  background: var(--card-background);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--soft-stroke);
+  box-shadow: var(--shadow);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.chat-composer__input {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border: 1px solid var(--soft-stroke);
+  border-radius: 1.5rem;
+  padding: 0.75rem 1rem;
+  background: #f9fafb;
+}
+
+.chat-icon-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--accent);
+  font-size: 1.1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chat-icon-btn:hover {
+  background: rgba(99, 102, 241, 0.24);
+}
+
+.chat-composer__textarea {
+  flex: 1;
+  resize: none;
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: var(--text-primary);
+  min-height: 42px;
+}
+
+.chat-composer__textarea:focus {
+  outline: none;
+}
+
+.chat-composer__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.chat-composer__status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.82rem;
+  color: var(--text-tertiary);
+}
+
+.chat-mode-chip {
+  background: rgba(34, 197, 94, 0.14);
+  color: #15803d;
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.78rem;
+}
+
+.chat-composer__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
 @media (max-width: 1100px) {
   .app-main {
     padding: 2.5rem;
+  }
+
+  .chat-layout {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .chat-sidebar-panel {
+    order: 2;
+  }
+
+  .chat-main-panel {
+    order: 1;
   }
 }
 
@@ -495,6 +974,22 @@ button:disabled {
 
   .sidebar__footer {
     padding-top: 1rem;
+  }
+
+  .chat-welcome-card__content {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.5rem;
+  }
+
+  .chat-welcome-card__actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .chat-thread {
+    max-height: none;
   }
 }
 
@@ -540,6 +1035,39 @@ button:disabled {
     flex: 1;
     min-width: auto;
   }
+
+  .chat-header__actions {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
+  .chat-header__actions .chat-primary-btn,
+  .chat-header__actions .chat-secondary-btn {
+    flex: 1;
+    min-width: 160px;
+  }
+
+  .chat-layout {
+    gap: 1.25rem;
+  }
+
+  .chat-composer__status {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4rem;
+  }
+
+  .chat-composer__actions {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
+  .chat-composer__actions .chat-primary-btn,
+  .chat-composer__actions .chat-secondary-btn {
+    flex: 1;
+  }
 }
 
 @media (max-width: 600px) {
@@ -551,5 +1079,60 @@ button:disabled {
   .file-table__file-cell {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .chat-sidebar-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.6rem;
+  }
+
+  .chat-sidebar-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.65rem;
+  }
+
+  .chat-sidebar-item__status {
+    align-self: flex-start;
+  }
+
+  .chat-header__actions .chat-primary-btn,
+  .chat-header__actions .chat-secondary-btn {
+    min-width: 0;
+  }
+
+  .chat-message,
+  .chat-message--user {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .chat-message__bubble {
+    max-width: 100%;
+  }
+
+  .chat-message--user .chat-message__bubble {
+    align-self: flex-end;
+  }
+
+  .chat-message__avatar {
+    align-self: flex-start;
+  }
+
+  .chat-welcome-card {
+    padding: 1.5rem;
+  }
+
+  .chat-composer__actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.6rem;
+  }
+
+  .chat-composer__actions .chat-primary-btn,
+  .chat-composer__actions .chat-secondary-btn {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- add navigation state so the sidebar can open the dataset or chat experiences
- create a chat workspace screen with pinned conversations, task lists, and a live message thread
- extend the shared styles to support the new chat layout, controls, and responsive behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ce2af3d90c832bbfb2f54abcf9c00e